### PR TITLE
Move the mysql-configured file to /var/lib/mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:centos6
 MAINTAINER Dennis Kanbier <dennis@kanbier.net>
 
 # Update base images.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ ! -f /mysql-configured ]; then 
- 	/sbin/service mysqld restart 
+if [ ! -f /var/lib/mysql/mysql-configured ]; then
+ 	/sbin/service mysqld restart
 
  	/usr/bin/mysql_upgrade
 
@@ -13,7 +13,7 @@ if [ ! -f /mysql-configured ]; then
 
 	 echo "$MYSQL_PASSWORD" > /mysql-root-pw.txt
 
-	 mysqladmin -uroot password $MYSQL_PASSWORD 
+	 mysqladmin -uroot password $MYSQL_PASSWORD
 
 	 mysql -uroot -p"$MYSQL_PASSWORD" -e "INSERT INTO mysql.user (Host,User,Password) VALUES('%','admin',PASSWORD('${MYSQL_PASSWORD}'));"
 
@@ -35,7 +35,7 @@ if [ ! -f /mysql-configured ]; then
 
 	 /sbin/service mysqld stop
 
-	 touch /mysql-configured
+	 touch /var/lib/mysql/mysql-configured
 fi
 
 mysqld_safe


### PR DESCRIPTION
As the data are located in a volume mounted on `/var/lib/mysql`
the initialization located on `/` could may not reflect the actual
state of the database. For instance if the mysql container is
recreated while keeping the data, `start.sh` will try to reinit
the database.
